### PR TITLE
Use browser history to avoid hash in URL

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {Router, Route, IndexRoute, Link, browserHistory, hashHistory} from 'react-router';
+import {Router, Route, IndexRoute, Link, browserHistory } from 'react-router';
 
 import App from './components/App.jsx';
 import Home from './components/Home.jsx';
@@ -924,7 +924,7 @@ class MoleculeSurfaceDescriptionWrapper extends React.Component {
 }
 
 ReactDOM.render(
-    <Router history={hashHistory}>
+    <Router history={browserHistory}>
         <Route path="/" component={App}>
             <IndexRoute component={HomeWrapper}/>
             <Route path="molecule/:moleculeName" component={MoleculeInformationWrapper}/>


### PR DESCRIPTION
Uses the browser history package instead of the hash one that puts ugly looking hashes in the URL to maintain state. There is only one problem with doing this: you can no longer access the website directly through a link to a subpage. That is, https://yourapp.example.xyz/ will serve the front page of the app (and let you navigate to subpages such as /molecule/Molecule3), but you cannot paste that subpath into the browser URL and expect a response.

Solving this would require a simple server that _always_ serves index.html regardless of which subpath is requested.

Screenshots (Please ignore the fact that Bootstrap didn't load):

Before:

![image](https://cloud.githubusercontent.com/assets/1404650/21029609/e1fb3430-bd9a-11e6-9e61-30ec32ca9c24.png)

After:

![image](https://cloud.githubusercontent.com/assets/1404650/21029629/fbb4b928-bd9a-11e6-9dda-cc4cbeb20a33.png)

NB: This only works when served from (any) webserver. You cannot use browserHistory if you're serving from the file system, i.e., your URL looks like `file://…………`.

If you have python installed, the easiest way to serve the files on `http://localhost:6969` is probably `python -m SimpleHTTPServer 6969` for Python 2) or `python -m http.server 6969` for Python 3.

A better solution would be to write a simple Node script that accepts all routes and always responds with index.html, except for requests to the app's CSS or JS bundle. I can help with that tomorrow if you want.